### PR TITLE
fix: invalid ret for `FindChannelName`

### DIFF
--- a/libs/libyasdimaster.c
+++ b/libs/libyasdimaster.c
@@ -330,7 +330,7 @@ SHARED_FUNCTION DWORD FindChannelName(DWORD devh, char * ChanName)
 
    //check params...
    res = libResolveHandles(devh, INVALID_HANDLE, &dev, NULL, __func__ );
-   if (YE_OK != res ) return res;
+   if (YE_OK != res ) return INVALID_HANDLE;
 
    chan = TNetDevice_FindChannelName(dev, ChanName);
    if (!chan)


### PR DESCRIPTION
The function returna a `DWORD` which is typedef for `unsigned int`. `libResolveHandles` return negative values which makes the  error indistinguishable from a valid return.